### PR TITLE
adds or operator to match option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+##### 1.1.5 (2017-02-04)
+- Fix: check for empty replace object, and ignore it if empty.
+
+
 ##### 1.1.4 (2016-08-23)
 - Fix: check type constructor for custom types.
 - Polish: update dependencies.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 sapeien <sapeien@airmail.cc>
+Copyright (c) 2017 Dali Zheng <d@liwa.li> (http://daliwa.li)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,12 +66,21 @@ module.exports = Adapter => class MongodbAdapter extends Adapter {
     const isArrayKey = this.keys.isArray
     const typeMap = this.options.typeMap
     const collection = type in typeMap ? typeMap[type] : type
-    let query = { $and: [] }
+    let query = { $and: [], $or: [] }
 
     if ('match' in options)
-      query.$and.push(mapValues(options.match, value =>
-        Array.isArray(value) ? { $in: value } : value))
-
+      // check for or operator
+      if ( 'or' in options.match ){ 
+        for (const key in options.match.or ) {
+          let q = {}; 
+          q[key] = options.match.or[key]; 
+          query.$or.push( q )
+        }
+      }
+      else {
+        query.$and.push(mapValues(options.match, value =>
+          Array.isArray(value) ? { $in: value } : value))
+      }
     if ('exists' in options)
       query.$and.push(mapValues(options.exists, (value, key) => {
         if (!(key in recordTypes[type])) return void 0
@@ -106,6 +115,7 @@ module.exports = Adapter => class MongodbAdapter extends Adapter {
     }
 
     if (!query.$and.length) delete query.$and
+    if (!query.$or.length) delete query.$or
 
     if ('query' in options) {
       const result = options.query(query)
@@ -181,7 +191,7 @@ module.exports = Adapter => class MongodbAdapter extends Adapter {
       new Promise((resolve, reject) => {
         const modifiers = {}
 
-        if ('replace' in update)
+        if ('replace' in update && Object.keys(update.replace).length)
           modifiers.$set = update.replace
 
         if ('push' in update)

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,10 +70,10 @@ module.exports = Adapter => class MongodbAdapter extends Adapter {
 
     if ('match' in options)
       // check for or operator
-      if ( 'or' in options.match ){ 
+      if ( 'or' in options.match ) {
         for (const key in options.match.or ) {
-          let q = {}; 
-          q[key] = options.match.or[key]; 
+          const q = {}
+          q[key] = options.match.or[key]
           query.$or.push( q )
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fortune-mongodb",
   "description": "MongoDB adapter for Fortune.",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -14,17 +14,17 @@
   },
   "main": "./lib/index.js",
   "dependencies": {
-    "mongodb": "^2.2.10"
+    "mongodb": "^2.2.22"
   },
   "devDependencies": {
     "@tap-format/dot": "^0.2.0",
     "chalk": "^1.1.3",
-    "eslint": "^3.8.1",
-    "eslint-config-boss": "^1.0.4",
-    "fortune": "^4.2.10",
+    "eslint": "^3.15.0",
+    "eslint-config-boss": "^1.0.5",
+    "fortune": "^5.1.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.5.4",
-    "tapdance": "^4.1.2"
+    "tapdance": "^5.0.3"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
Fixes a bug where when you use the official `{match: { or: { key: value, key: value } } }` syntax it wasn't translating to a correct mongodb query.